### PR TITLE
fix: make compatible with Windows

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,11 +1,7 @@
 import { createHash, createHmac, Hmac } from 'crypto';
-import { readFileSync } from 'fs';
 import { Readable, Writable } from 'stream';
 
-const readPackageJson = (path: string) =>
-  JSON.parse(readFileSync(path, 'utf8'));
-
-const pkg = readPackageJson(__dirname + '/../../../package.json');
+const pkg = require("../../../package.json");
 
 export const NAME = pkg.name;
 export const VERSION = pkg.version;


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes the compatibility issue with MS Windows.

* **What is the current behavior?** (You can also link to an open issue here)

I was seeing the following error:

```
Uncaught Error: ENOENT: no such file or directory, open 'C:\Users\jaese\Documents\Github\myproj\src/../../../package.json'
    at Object.openSync (fs.js:466)
    at Object.func [as openSync] (electron/js2c/asar_bundle.js:5)
    at readFileSync (fs.js:368)
    at e.readFileSync (electron/js2c/asar_bundle.js:5)
    at readPackageJson (util.js:4)
    at ./node_modules/node-aescrypt/build/module/lib/util.js (util.js:5)
    at Module.options.factory (react refresh:6)
    at __webpack_require__ (bootstrap:21)
    at fn (hot module replacement:60)
    at ./node_modules/node-aescrypt/build/module/lib/decrypt.js (renderer.dev.js:28477)
```

* **What is the new behavior (if this is a feature change)?**

I am now able to import the library without seeing any errors.

* **Other information**:

N/A